### PR TITLE
Allow more flexibility in command line

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,78 @@ public class Program
   }
 }
 ```
-There will be one command 'file' with two subcommands 'create' and 'delete'
+There will be one command 'file' with two subcommands 'create' and 'delete'.
+Methods, marked with `[Ignore]` will not be used as commands.
+
+### Tasks
+Methods that returns `Task` or `Task<T>` are supported
+
+### Default commands
+If only one command exists in a file - then it is **default** command (you don't need to specify it's name to run it). 
+In other case **default** command can be specified by:
+1. **`[DefaultCommand]` attribute**: Apply `[DefaultCommand]` to a method or nested class.
+2. **XML doc**: Set `<summary default="true">` on the method or class (can have no effect on "generated for viewing" code in some IDE's)
+
+```cs
+[App]
+public class Program
+{
+    // This is the only method, so it's automatically the default command.
+    public static void Run(string name, int count = 1) { ... }
+}
+```
+
+```cs
+[App]
+public class Program
+{
+    /// <summary default="true">"default" can be also used to mark default command</summary>    
+    [DefaultCommand]
+    public static void Run(string name) { ... }
+
+    public static void OtherCommand(string arg) { ... }
+}
+```
+### Argument syntax
+Supported command and argument names can be in `kebab-case`, `snake_case`, `dot.case`, all case insensitive(configurable). Supported argument prefixes `/`, `-` and `--` (configurable). Supported name value separators are `:`, `=` and whitespace (configurable).
+```sh
+> myapp MyFancyCommand --MyFancyOption 123  #OK - Case insensitive matching
+> myapp my-fancy-command /my-fancy-option:123  #OK - kebab-case, '/' and ':'
+> myapp my_fancy_command -my-fancy-option=123  #OK - snake_case, '-' and '='
+> myapp my.fancy.command --my.fancy.option 123  #OK - dot.case, '--' and ' '
+```
+
+### Mandatory and optional parameters
+Mandatory parameters (method arguments without default values) can be passed **positionally** without name or **by name** (in any order) - using prefixes `/`, `-`, `--`.
+Optional parameters (options) can only be passed **by name**:
+```cs
+public static void Greet(string name, int times, int maybe = 0) { ... }
+```
+```sh
+> myapp greet John 3                     # positional mandatory
+> myapp greet John 3 --maybe 5           # positional mandatory with option
+> myapp greet John 3 5                   # options require names - will emit "Unexpected argument 5" error
+> myapp greet --times=3 --name=John      # named mandatory, reversed order
+> myapp greet John --times=3             # mixed positional + named
+> myapp greet --times 3 --maybe 5        # name missing - will emit error
+```
+If a mandatory parameter is missing, the parser prints an error:
+```
+Missing required parameter 'name'
+```
+
+### Parameter aliases
+Both mandatory and optional parameters support short aliases via the `alias` xmldoc attribute:
+```cs
+/// <param name="name" alias="n">User name</param>
+/// <param name="output" alias="o">Output file</param>
+public static void Greet(string name, string output = "out.txt") { ... }
+```
+```
+> myapp greet -n=John -o=result.txt
+> myapp greet -n John                # space-separated
+```
+Aliases use single-character prefixes (`-`, `/`) and appear in help text (e.g. `-n|name`).
 
 ### Shell autocompletion
 Generator automaticaly creates command 'complete' that accepts cursor position and argument list. 
@@ -52,10 +123,6 @@ Using this command you can create autocompletion script for your shell.
 If you mistyped command or option name it will print suggestion "Did you mean "command-name?"".
 
 **Disabled by default. To enable this feature insert `<GenerateSuggestions>True</GenerateSuggestions>` into your .csproj**
-### Tasks
-Methods that returns `Task` or `Task<T>` are supported
-### Default commands
-You can mark method or class with setting summary's attribute default to "true" 
 ## Type convertion
 ***Supported any type*** that has static method Parse(string) or TryParse(string, out T) or with constructor with one argument of type string.
 For example, int or FileInfo.
@@ -102,7 +169,97 @@ Also you can specify default language by setting project's property `DefaultLang
 <PropertyGroup>
     <LogGeneratedParser>Path-to-parser-dir</LogGeneratedParser>
 </PropertyGroup>
-``` 
+```
+
+### Other [App] parameters
+The `[App]` attribute accepts optional properties to control how arguments are parsed. All default to accepting all variants for maximum flexibility.
+
+### Argument prefixes
+Control which prefixes are accepted for options and named parameters via `ArgPrefix`:
+```cs
+[App(ArgPrefix = PrefixStyle.DoubleHyphen | PrefixStyle.Slash)] // accepts --option and /option, but not -option
+```
+Available flags: `DoubleHyphen` (`--`), `Hyphen` (`-`), `Slash` (`/`). Default: `All`.
+```
+> myapp my-command --name=John /age=30 -v
+```
+
+### Value separators
+Control how values are separated from option/parameter names via `ValueSeparator`:
+```cs
+[App(ValueSeparator = SeparatorStyle.Equals | SeparatorStyle.Whitespace)] // --name=John or --name John, but not --name:John
+```
+Available flags: `Whitespace` (` `), `Colon` (`:`), `Equals` (`=`). Default: `All`.
+
+### Naming styles
+Control accepted naming conventions for parameters, options, and enum values via `ParamStyle` and `EnumStyle`:
+```cs
+[App(ParamStyle = NamingStyle.KebabCase | NamingStyle.CaseInsensitive, EnumStyle = NamingStyle.NoSeparator)]
+```
+Available flags: `KebabCase` (`my-param`), `SnakeCase` (`my_param`), `DotCase` (`my.param`), `NoSeparator` (`myparam`), `CaseInsensitive`. Default: `AllVariants` (all of the above).
+
+For a method parameter `myParam`:
+```
+--my-param=val   # KebabCase
+--my_param=val   # SnakeCase
+--my.param=val   # DotCase
+--myparam=val    # NoSeparator
+--MY-PARAM=val   # CaseInsensitive (combinable with any of the above)
+```
+### Mandatory parameter style
+Control how mandatory parameters are passed via `MandatoryStyle`:
+```cs
+[App(MandatoryStyle = MandatoryStyle.Positional)]  // positional only
+[App(MandatoryStyle = MandatoryStyle.Named)]        // named only (--param=value)
+[App(MandatoryStyle = MandatoryStyle.Mixed)]        // both (default)
+```
+- **Mixed** (default): parameters can be passed positionally or by name — current behavior, fully backward compatible.
+- **Positional**: parameters can only be passed positionally (`command val1 val2`). Named `--param` case labels are not generated.
+- **Named**: parameters must be passed by name (`command --param=value`). Positional fallback is disabled — unmatched arguments produce an error.
+
+#### SkipCommandParsing
+When a default command has no sibling commands, the generated parser normally still tries to match the command name.
+```cs
+[App]
+public class Program
+{
+    public static void Message(string msg, bool flag = false) { Console.WriteLine($"Sending \"{msg}\" ({flag})") }
+}
+```
+```sh
+> myapp text --flag
+Sending "text" (True)
+
+> myapp message --flag     # "message" is treated as command name, as it matches one
+Error: Missing required parameter 'msg'
+```
+Set `SkipCommandParsing = true` to skip this — all arguments go directly to parameter/option parsing:
+```cs
+[App(SkipCommandParsing = true)]
+```
+```sh
+> myapp message --flag    # "myfile.txt" is parsed as the 'file' parameter, not as a command name
+Sending "message" (True)
+```
+Combine with overriden `HelpCommand` to pass really any string as parameter.
+#### HelpCommand
+By default the help command word is `"help"`. You can change it or disable it entirely:
+```cs
+[App(HelpCommand = "info")]   // use "info" instead of "help"
+```
+The parser also accepts prefixed variants at the root level (e.g. `--help`, `-help`, `/help` or `--info`, etc.).
+When disabled (`""` or null), no help case is generated — then any first string (including "help") treated as a positional parameter to a default command.
+```sh
+> myapp help --flag
+Usage: [command] <parameters> [options] ....
+```
+```cs
+[App(HelpCommand = null)]       // disable help command entirely
+```
+```sh
+> myapp help --flag
+Sending "help" (True)    # "help" is used as first parameter 
+```
 ## Install
 ```
 dotnet add package CommandLineArgsGenerator

--- a/samples/DefaultCommand/DefaultCommand.csproj
+++ b/samples/DefaultCommand/DefaultCommand.csproj
@@ -3,8 +3,13 @@
     <OutputType>Exe</OutputType>
     <TargetFramework>net6.0</TargetFramework>  
     <Nullable>enable</Nullable>
-  </PropertyGroup> 
+  </PropertyGroup>
+  <PropertyGroup>
+	<GenerateCompletion>True</GenerateCompletion>
+	<GenerateSuggestions>True</GenerateSuggestions>
+  </PropertyGroup>
   <ItemGroup>
     <ProjectReference ReferenceOutputAssembly="false" OutputItemType="Analyzer" Include="..\..\src\CommandLineArgsGenerator.csproj" />
   </ItemGroup>
+  <Import Project="..\..\src\build\CommandLineArgsGenerator.targets" />	
 </Project>

--- a/samples/DefaultCommand/Program.cs
+++ b/samples/DefaultCommand/Program.cs
@@ -1,10 +1,44 @@
+using System;
+using CommandLineArgsGenerator.Styles;
+
 namespace DefaultCommand;
 
-[App]
+[App(HelpCommand = null, SkipCommandParsing = true)]
 public static class Program
 {
     /// <summary default="true">
     /// This command is invoked when the user doesn't specify any sub command.
     /// </summary>
-    public static int DefaultCommand() => 0;
+    [DefaultCommand]
+    public static int DefaultCommand(string param, bool flag = false)
+    {
+        Console.WriteLine($"DefaultCommand {param} {(flag ? "true" : "")}");
+        return 0;
+    }
+
+    public enum EnumParam
+    {
+        EnumValue1,
+        EnumValue2,
+        EnumValue3,
+        EnumValue4,
+        EnumValue5
+    }
+
+    /// <summary>
+    /// This command is to test optional parameters syntax
+    /// </summary>
+    /// <param name="mandatory1" alias="m">mandatory string value</param>
+    /// <param name="mandatory2" alias="n">mandatory int value</param>
+    /// <param name="arrayParam">array of strings</param>
+    /// <param name="intParam" alias="i">optional int value</param>
+    /// <param name="enumParam">valid values: EnumValue1, EnumValue2, ... EnumValue5 </param>
+    /// <returns></returns>
+    public static void OptionalArgsTest(string mandatory1, int mandatory2, string[]? arrayParam , int? intParam = null,
+        EnumParam? enumParam = null)
+    {
+        Console.WriteLine($"Invoked {mandatory1}-{mandatory2} with intParam={intParam}, enumParam={enumParam}, arrayParam={string.Join(",",arrayParam ?? new string[] {})}");
+    }
+    
+    public static void AnotherCommand() { }
 }

--- a/src/CommandInfo.cs
+++ b/src/CommandInfo.cs
@@ -13,27 +13,27 @@ namespace CommandLineArgsGenerator
         public override bool Equals(object obj)
         {
             return obj is CommandInfo info &&
-                   Name == info.Name;
+                   RawName == info.RawName;
         }
 
         public override int GetHashCode()
         {
-            return 539060726 + EqualityComparer<string>.Default.GetHashCode(Name);
+            return 539060726 + EqualityComparer<string>.Default.GetHashCode(RawName);
         }
         public override string ToString()
         {
             var sb = new StringBuilder();
-            sb.Append(Name);
+            sb.Append(RawName);
             foreach(var p in Parameters)
             {
                 sb.Append(" <");
-                sb.Append(p.Name);
+                sb.Append(p.RawName);
                 sb.Append("> ");
             }
             foreach (var p in Options)
             {
                 sb.Append(" -");
-                sb.Append(p.Name);
+                sb.Append(p.RawName);
             }
             return sb.ToString();
         }

--- a/src/CommandInfoBase.cs
+++ b/src/CommandInfoBase.cs
@@ -1,20 +1,12 @@
-﻿namespace CommandLineArgsGenerator
+namespace CommandLineArgsGenerator
 {
-    public abstract class CommandInfoBase 
+    public abstract class CommandInfoBase
 	{
-        public string Name { get; set; }
+        public string[] NameVariants { get; set; }
+        public string[] FullNameVariants { get; set; }
         public virtual HelpText? HelpText { get; set; }
         public string RawName { get; set; }
-		private string fullName;
-        public string FullName 
-		{ 
-			get => fullName;  
-			set {
-				fullName = value;
-				UnderscoredName = fullName.Replace(" ", "_").Replace('-', '_');
-			}
-		}
 		public string UnderscoredName { get; set; }
-		
+
 	}
-} 
+}

--- a/src/CommandLineArgsGenerator.csproj
+++ b/src/CommandLineArgsGenerator.csproj
@@ -28,6 +28,9 @@
         <Compile Remove="templates\*.cs"/>
     </ItemGroup>
     <ItemGroup>
+        <EmbeddedResource Include="StyleEnums.cs" LogicalName="CommandLineArgsGenerator.StyleEnums.cs"/>
+    </ItemGroup>
+    <ItemGroup>
         <Content Include="build\*.*">
           <Pack>true</Pack>
           <PackagePath>build\</PackagePath>
@@ -45,6 +48,9 @@
     </ItemGroup>
     <ItemGroup>
         <PackageReference Include="Scriban" Version="5.5.0" IncludeAssets="Build"/>
+    </ItemGroup>
+    <ItemGroup>
+        <None Include="build/CommandLineArgsGenerator.targets" Pack="True" PackagePath="build/CommandLineArgsGenerator.targets" />
     </ItemGroup>
     <ItemGroup>
         <None Include="$(OutputPath)\$(AssemblyName).dll" Pack="true" PackagePath="analyzers/dotnet/cs" Visible="false"/>

--- a/src/FilesGenerator.cs
+++ b/src/FilesGenerator.cs
@@ -12,7 +12,7 @@ namespace CommandLineArgsGenerator
 			var manifestNames = asm.GetManifestResourceNames();
             var csSources =
                 manifestNames
-                    .Where(name => name.EndsWith(".cs"));
+                    .Where(name => name.StartsWith("CommandLineArgsGenerator.templates.") && name.EndsWith(".cs"));
             var fileNames = 
                 csSources
                     .Select(name => name.Replace("CommandLineArgsGenerator.templates.", ""));

--- a/src/OptionInfo.cs
+++ b/src/OptionInfo.cs
@@ -4,8 +4,7 @@ namespace CommandLineArgsGenerator
     public class OptionInfo : ParameterInfo
     {
         public string? Default { get; set; }
-        public string? Alias { get; set; }
-        public bool IsArray { get; set; }
+        public override bool IsArray { get; set; }
         public bool IsBool => Type?.SpecialType == SpecialType.System_Boolean;
     }
 

--- a/src/ParameterInfo.cs
+++ b/src/ParameterInfo.cs
@@ -7,10 +7,11 @@ namespace CommandLineArgsGenerator
 {
     public class ParameterInfo
     {
-        public string Name { get; set; }
+        public string[] NameVariants { get; set; }
         public string RawName { get; set; }
         public INamedTypeSymbol Type { get; set; }
-        public HelpText? HelpText { get; set; } 
+        public string? Alias { get; set; }
+        public HelpText? HelpText { get; set; }
         public bool IsNullable { get; set; }
         
         private string displayTypeName;
@@ -27,6 +28,7 @@ namespace CommandLineArgsGenerator
             } 
         }
         public string UnderscoredTypeName { get; set; }
+		public virtual bool IsArray { get; set; }
 		public bool IsString => Type?.SpecialType == SpecialType.System_String;
 		public bool IsEnum => Type?.BaseType?.SpecialType == SpecialType.System_Enum;
 

--- a/src/ParserGenerator.cs
+++ b/src/ParserGenerator.cs
@@ -13,6 +13,7 @@ using System.Xml.Linq;
 using Microsoft.CodeAnalysis.CSharp;
 using System.Diagnostics;
 using Scriban.Parsing;
+using CommandLineArgsGenerator.Styles;
 
 namespace CommandLineArgsGenerator
 {
@@ -32,6 +33,8 @@ namespace CommandLineArgsGenerator
         private static SymbolDisplayFormat typeFormat = new SymbolDisplayFormat(genericsOptions: SymbolDisplayGenericsOptions.IncludeTypeParameters, typeQualificationStyle: SymbolDisplayTypeQualificationStyle.NameAndContainingTypesAndNamespaces);
         private static readonly Template parserTemplate, helpTextsTemplate, enumParserTemplate, completionTemplate;
 		private string defaultLanguage = "";
+        private NamingStyle paramStyle = NamingStyle.AllVariants;
+        private NamingStyle enumStyle = NamingStyle.AllVariants;
         static ParserGenerator()
         {
             var asm = Assembly.GetExecutingAssembly();
@@ -66,16 +69,18 @@ namespace CommandLineArgsGenerator
 				defaultLanguage = context.GetMSBuildProperty("DefaultLanguage");
                 defaultLanguage = string.IsNullOrWhiteSpace(defaultLanguage) ? "en" : defaultLanguage;
 				var semanticModel = context.Compilation.GetSemanticModel(receiver.Root.Class.SyntaxTree);
-                var cmds = GetCommands(receiver.Root.Class, semanticModel, out CommandInfoBase? defaultCommand);
+                paramStyle = receiver.Root.ParamStyle;
+                enumStyle = receiver.Root.EnumStyle;
+                var cmds = GetCommands(receiver.Root.Class, semanticModel, out CommandInfoBase? defaultCommand, paramStyle);
                 var rootDoc = GetXmlDocumentation(receiver.Root.Class);
-                
+
 				var rh = rootDoc.Descendants("summary").FirstOrDefault();
 				if(rh is not null)
 				{
 					receiver.Root.HelpText = HelpText.FromXElement(rh, defaultLanguage);
 				}
                 receiver.Root.Children = cmds;
-                receiver.Root.Default = defaultCommand; 
+                receiver.Root.Default = defaultCommand;
 				
                 var enums = 
                     GetEnumsInfo(defaultCommand is null ? cmds : cmds.Append(defaultCommand))
@@ -84,7 +89,7 @@ namespace CommandLineArgsGenerator
                 
                 bool.TryParse(context.GetMSBuildProperty("GenerateCompletion"), out bool genComp);
                 bool.TryParse(context.GetMSBuildProperty("GenerateSuggestions"), out bool genSugg);
-                
+               
                 Queue<string> errors = new();
                 var ctx = CreateContext(CreateParserTemplateModel(receiver, context), errors);
                 string entryPoint = parserTemplate.Render(ctx);
@@ -139,31 +144,59 @@ namespace CommandLineArgsGenerator
             return enums;
                 
         }
+		private (string[] optionPrefixes, string[] aliasPrefixes) GetPrefixArrays(PrefixStyle argPrefix)
+		{
+            var optionPrefixes = new List<string>();
+            var aliasPrefixes = new List<string>();
+            if (argPrefix.HasFlag(PrefixStyle.DoubleHyphen)) { optionPrefixes.Add("--"); }
+            if (argPrefix.HasFlag(PrefixStyle.Hyphen)) { optionPrefixes.Add("-"); aliasPrefixes.Add("-"); }
+            if (argPrefix.HasFlag(PrefixStyle.Slash)) { optionPrefixes.Add("/"); aliasPrefixes.Add("/"); }
+            if (aliasPrefixes.Count == 0) aliasPrefixes.Add("-"); // fallback for aliases
+            return (optionPrefixes.ToArray(), aliasPrefixes.ToArray());
+		}
 		private object CreateParserTemplateModel(ParserSyntaxReceiver receiver, GeneratorExecutionContext context)
-		{ 
+		{
             bool.TryParse(context.GetMSBuildProperty("GenerateCompletion"), out bool genComp);
             bool.TryParse(context.GetMSBuildProperty("GenerateSuggestions"), out bool genSugg);
+            var root = receiver.Root!;
+            var (optionPrefixes, aliasPrefixes) = GetPrefixArrays(root.ArgPrefix);
 			return new {
 				Namespace = receiver.Namespace,
-				Root = receiver.Root,
+				Root = root,
 				Converters = receiver.Converters.GroupBy(x => x.Value).ToDictionary(t => t.Key, t => t.Select(r => r.Key).ToList()),
 		        GenerateCompletion = genComp,
                 GenerateSuggestions = genSugg,
+                ParamCaseInsensitive = root.ParamStyle.HasFlag(NamingStyle.CaseInsensitive),
+                SeparatorColon = root.ValueSeparator.HasFlag(SeparatorStyle.Colon),
+                SeparatorEquals = root.ValueSeparator.HasFlag(SeparatorStyle.Equals),
+                OptionPrefixes = optionPrefixes,
+                AliasPrefixes = aliasPrefixes,
+                SkipCommandParsing = root.SkipCommandParsing && root.Children.Count == 0 && root.Default != null,
+                HelpCommand = root.HelpCommand,
+                MandatoryNamed = root.MandatoryStyle == MandatoryStyle.Named || root.MandatoryStyle == MandatoryStyle.Mixed,
+                MandatoryPositional = root.MandatoryStyle == MandatoryStyle.Positional || root.MandatoryStyle == MandatoryStyle.Mixed,
             };
 		}
 		private object CreateHelpTextsModel(ParserSyntaxReceiver receiver)
 		{
+            var (optionPrefixes, aliasPrefixes) = GetPrefixArrays(receiver.Root!.ArgPrefix);
 			return new {
 				Namespace = receiver.Namespace,
 				Root = receiver.Root,
 				DefaultLanguage = defaultLanguage,
+				OptionPrefixes = optionPrefixes,
+				AliasPrefixes = aliasPrefixes,
+				HelpCommand = receiver.Root.HelpCommand,
+				MandatoryNamed = receiver.Root!.MandatoryStyle == MandatoryStyle.Named || receiver.Root!.MandatoryStyle == MandatoryStyle.Mixed,
 			};
 		}
 		public object CreateEnumsModel(string @namespace,(string[] values, string typeName, string displayTypeName)[] enums)
         {
             return new {
                 Namespace = @namespace,
-                EnumsInfo = enums
+                EnumsInfo = enums,
+                EnumCaseInsensitive = enumStyle.HasFlag(NamingStyle.CaseInsensitive),
+                EnumStyleFlags = (int)enumStyle,
             };
         }
         private TemplateContext CreateContext(object model, Queue<string> errors)
@@ -173,8 +206,9 @@ namespace CommandLineArgsGenerator
 			sc.Import("HasCtor", (Func<ParameterInfo, IEnumerable<object>, bool>)((param, args) => param.HasCtor(args.Cast<string>().ToArray())));
 			sc.Import("JoinParamsAndOptions", (Func<CommandInfo, string>)((cmd) => string.Join(", ", cmd.Parameters.Concat(cmd.Options).Select(p => p.RawName))));
 			sc.Import("Join", ((Func<IEnumerable<object>, string, string>)((e, c) => string.Join(c, e))));
-            sc.Import("GetEnumMembers", ((Func<INamedTypeSymbol, IEnumerable<string>>)(x => x.GetMembers().Where(m => m.Name != ".ctor").Select(m => TransformName(m.Name)))));
-            sc.Import("TransformName", (Func<string,string>)TransformName);
+            var capturedEnumStyle = enumStyle;
+            sc.Import("GetEnumMembers", ((Func<INamedTypeSymbol, IEnumerable<string>>)(x => x.GetMembers().Where(m => m.Name != ".ctor").Select(m => GetNameVariants(m.Name, capturedEnumStyle)[0]))));
+            sc.Import("GetNameVariants", (Func<string, string[]>)(name => GetNameVariants(name, capturedEnumStyle)));
             sc.Import("Error", (Action<string>)(error => errors.Enqueue(error)));
 			var ctx = new TemplateContext();
 			ctx.PushGlobal(sc);
@@ -182,18 +216,25 @@ namespace CommandLineArgsGenerator
 			ctx.MemberRenamer = x => x.Name;
 			return ctx;
 		}
-        private List<CommandInfoBase> GetCommands(ClassDeclarationSyntax @class, SemanticModel semanticModel, out CommandInfoBase? defaultCommand, string? prevName = null)
+        private void SetNameVariants(CommandInfoBase cmd, NamingStyle style, string[]? parentFullNameVariants)
+        {
+            cmd.NameVariants = GetNameVariants(cmd.RawName, style);
+            cmd.FullNameVariants = parentFullNameVariants != null
+                ? parentFullNameVariants.SelectMany(p => cmd.NameVariants.Select(n => p + " " + n)).ToArray()
+                : cmd.NameVariants;
+            cmd.UnderscoredName = cmd.FullNameVariants[0].Replace(" ", "_").Replace('-', '_').Replace('.', '_');
+        }
+        private List<CommandInfoBase> GetCommands(ClassDeclarationSyntax @class, SemanticModel semanticModel, out CommandInfoBase? defaultCommand, NamingStyle style, string[]? parentFullNameVariants = null)
         {
             defaultCommand = null;
             var cmds = new List<CommandInfoBase>();
             var methods = GetMethods(@class);
             foreach (var method in methods)
             {
-                
+
                 var doc = GetXmlDocumentation(method);
                 var rawName = method.Identifier.ToString().Trim();
                 var paramAndOpts = GetParamsAndOptions(method, doc, semanticModel);
-                var name = TransformName(rawName); 
 				var h = doc.Descendants("summary").FirstOrDefault();
 				HelpText? help = null;
 				if(h is not null)
@@ -202,31 +243,36 @@ namespace CommandLineArgsGenerator
 				}
                 var cmd = new CommandInfo
                     {
-                        Name = name,
                         RawName = rawName,
                         NameInSourceCode = ParserSyntaxReceiver.GetFullName(method),
-                        FullName = prevName is not null ? $"{prevName} {name}" : name,
                         Parameters = paramAndOpts.parameters,
                         Options = paramAndOpts.options,
                         HelpText = help,
                         IsTask = semanticModel.GetTypeInfo(method.ReturnType).Type?.Name == "Task",
                     };
-                if(defaultCommand is null && doc.Descendants("summary").FirstOrDefault()?.Attribute("default")?.Value == "true")
+                SetNameVariants(cmd, style, parentFullNameVariants);
+                foreach (var p in paramAndOpts.parameters)
+                    p.NameVariants = GetNameVariants(p.RawName, style);
+                foreach (var o in paramAndOpts.options)
+                    o.NameVariants = GetNameVariants(o.RawName, style);
+                bool hasDefaultAttr = method.AttributeLists
+                    .SelectMany(al => al.Attributes)
+                    .Any(a => a.Name.ToString() == "DefaultCommand" || a.Name.ToString() == "DefaultCommandAttribute");
+                if(defaultCommand is null && (hasDefaultAttr || doc.Descendants("summary").FirstOrDefault()?.Attribute("default")?.Value == "true"))
                 {
                     defaultCommand = cmd;
                 }
                 else
                 {
-                    cmds.Add(cmd);    
+                    cmds.Add(cmd);
                 }
-                
+
             }
             var classes = GetClasses(@class);
             foreach (var cl in classes)
             {
                 var doc = GetXmlDocumentation(cl);
                 var rawName = cl.Identifier.ToString().Trim();
-                var name = TransformName(rawName);
                 var h = doc.Descendants("summary").FirstOrDefault();
 				HelpText? help = null;
 				if(h is not null)
@@ -235,15 +281,17 @@ namespace CommandLineArgsGenerator
 				}
 				var cmd = new RootCommand
                 {
-                    Name = name,
-                    FullName = prevName is not null ? $"{prevName} {name}" : name,
                     HelpText = help,
-                    Children = GetCommands(cl, semanticModel, out CommandInfoBase? defCmd, name),
                     Class = cl,
                     RawName = rawName,
-                    Default = defCmd
                 };
-                if(defaultCommand is null && doc.Descendants("summary").FirstOrDefault()?.Attribute("default")?.Value == "true")
+                SetNameVariants(cmd, style, parentFullNameVariants);
+                cmd.Children = GetCommands(cl, semanticModel, out CommandInfoBase? defCmd, style, cmd.FullNameVariants);
+                cmd.Default = defCmd;
+                bool hasDefaultAttr = cl.AttributeLists
+                    .SelectMany(al => al.Attributes)
+                    .Any(a => a.Name.ToString() == "DefaultCommand" || a.Name.ToString() == "DefaultCommandAttribute");
+                if(defaultCommand is null && (hasDefaultAttr || doc.Descendants("summary").FirstOrDefault()?.Attribute("default")?.Value == "true"))
                 {
                     defaultCommand = cmd;
                 }
@@ -251,6 +299,11 @@ namespace CommandLineArgsGenerator
                 {
                     cmds.Add(cmd);
                 }
+            }
+            if (defaultCommand is null && cmds.Count == 1 && parentFullNameVariants == null)
+            {
+                defaultCommand = cmds[0];
+                cmds.Clear();
             }
             return cmds;
         }
@@ -325,11 +378,11 @@ namespace CommandLineArgsGenerator
                 return new ParameterInfo
                 {
                     RawName = name,
-                    Name = TransformName(name),
                     Type = type as INamedTypeSymbol,
                     HelpText = help,
                     DisplayTypeName = displayTypeName,
                     IsNullable = isNullable,
+                    Alias = p?.Attribute("alias")?.Value,
                 };
             }
             else if (type.TypeKind == TypeKind.Array)
@@ -338,7 +391,6 @@ namespace CommandLineArgsGenerator
                 return new OptionInfo
                 {
                     RawName = name,
-                    Name = TransformName(name),
                     Type = t,
                     HelpText = help,
                     DisplayTypeName = t?.ToDisplayString(typeFormat) ?? "FUCK?",
@@ -352,7 +404,6 @@ namespace CommandLineArgsGenerator
                 return new OptionInfo
                 {
                     RawName = name,
-                    Name = TransformName(name),
                     Type = type as INamedTypeSymbol,
                     HelpText = help,
                     DisplayTypeName = displayTypeName ?? "FUCK?",
@@ -380,30 +431,77 @@ namespace CommandLineArgsGenerator
             return (parameters, options);
 
         }
-        private string TransformName(string name)
+        private static string[] GetNameVariants(string name, NamingStyle styleFlags)
         {
-            if(name.All(char.IsUpper))
-                return name.ToLower();
-            var sb = new StringBuilder();
-            sb.Append(char.ToLower(name[0]));
-            foreach (var item in name.AsSpan(1))
+            bool shouldLowercase = styleFlags.HasFlag(NamingStyle.CaseInsensitive);
+            var cleaned = name.Replace("@", "");
+
+            // Find word boundary positions (where separators should be inserted)
+            var splitPositions = new List<int>();
+            if (!cleaned.All(char.IsUpper)) // all-upper means single word (e.g. "URL")
             {
-                if (char.IsUpper(item))
+                for (int i = 1; i < cleaned.Length; i++)
                 {
-                    sb.Append('-');
-                    sb.Append(char.ToLower(item));
-                }
-                else if(item is not '@')
-                {
-                    sb.Append(item);
+                    if (char.IsUpper(cleaned[i]))
+                        splitPositions.Add(i);
                 }
             }
-            return sb.ToString();
+
+            if (splitPositions.Count == 0)
+            {
+                // Single word — no separators possible
+                return new[] { shouldLowercase ? cleaned.ToLower() : cleaned };
+            }
+
+            var separators = new List<(NamingStyle flag, char? sep)>
+            {
+                (NamingStyle.KebabCase, '-'),
+                (NamingStyle.SnakeCase, '_'),
+                (NamingStyle.DotCase, '.'),
+                (NamingStyle.NoSeparator, null),
+            };
+
+            var variants = new List<string>();
+            foreach (var (flag, sep) in separators)
+            {
+                if (!styleFlags.HasFlag(flag))
+                    continue;
+                var sb = new StringBuilder();
+                int prev = 0;
+                foreach (var pos in splitPositions)
+                {
+                    if (sb.Length > 0 && sep.HasValue)
+                        sb.Append(sep.Value);
+                    sb.Append(cleaned, prev, pos - prev);
+                    prev = pos;
+                }
+                if (sb.Length > 0 && sep.HasValue)
+                    sb.Append(sep.Value);
+                sb.Append(cleaned, prev, cleaned.Length - prev);
+
+                var result = sb.ToString();
+                // Separated variants are always lowercase; NoSeparator is lowercase only when CaseInsensitive
+                if (sep.HasValue || shouldLowercase)
+                    result = result.ToLower();
+                variants.Add(result);
+            }
+
+            if (variants.Count == 0)
+                variants.Add(shouldLowercase ? cleaned.ToLower() : cleaned);
+
+            return variants.ToArray();
         }
 
         public void Initialize(GeneratorInitializationContext context)
-        { 
-            context.RegisterForSyntaxNotifications(() => new ParserSyntaxReceiver()); 
+        {
+            context.RegisterForPostInitialization(ctx =>
+            {
+                var asm = Assembly.GetExecutingAssembly();
+                using var stream = asm.GetManifestResourceStream("CommandLineArgsGenerator.StyleEnums.cs");
+                using var reader = new System.IO.StreamReader(stream);
+                ctx.AddSource("StyleEnums.g.cs", reader.ReadToEnd());
+            });
+            context.RegisterForSyntaxNotifications(() => new ParserSyntaxReceiver());
         }
     }
 }

--- a/src/ParserSyntaxReceiver.cs
+++ b/src/ParserSyntaxReceiver.cs
@@ -8,6 +8,7 @@ using Microsoft.CodeAnalysis.CSharp;
 using System.Collections.Generic;
 using System.Reflection;
 using System;
+using CommandLineArgsGenerator.Styles;
 
 namespace CommandLineArgsGenerator
 {
@@ -29,7 +30,40 @@ namespace CommandLineArgsGenerator
                     {
                         if (attr.Name.ToString() == "App" || attr.Name.ToString() == "AppAttribute")
                         {
-                            var root = new RootCommand { Class = cl, Name = null };
+                            var root = new RootCommand { Class = cl };
+                            if (attr.ArgumentList != null)
+                            {
+                                foreach (var arg in attr.ArgumentList.Arguments)
+                                {
+                                    if (arg.NameEquals != null)
+                                    {
+                                        var propName = arg.NameEquals.Name.ToString();
+                                        var constantValue = semanticModel.GetConstantValue(arg.Expression);
+                                        if (constantValue.HasValue && constantValue.Value is int value)
+                                        {
+                                            switch (propName)
+                                            {
+                                                case "ParamStyle": root.ParamStyle = (NamingStyle)value; break;
+                                                case "EnumStyle": root.EnumStyle = (NamingStyle)value; break;
+                                                case "ValueSeparator": root.ValueSeparator = (SeparatorStyle)value; break;
+                                                case "ArgPrefix": root.ArgPrefix = (PrefixStyle)value; break;
+                                                case "MandatoryStyle": root.MandatoryStyle = (MandatoryStyle)value; break;
+                                            }
+                                        }
+                                        else if (propName == "SkipCommandParsing" && constantValue.HasValue && constantValue.Value is bool boolVal)
+                                        {
+                                            root.SkipCommandParsing = boolVal;
+                                        }
+                                        else if (propName == "HelpCommand" && constantValue.HasValue)
+                                        {
+                                            if (constantValue.Value is string strVal)
+                                                root.HelpCommand = string.IsNullOrEmpty(strVal) ? null : strVal;
+                                            else if (constantValue.Value == null)
+                                                root.HelpCommand = null;
+                                        }
+                                    }
+                                }
+                            }
                             return root;
                         }
                     }

--- a/src/RootCommand.cs
+++ b/src/RootCommand.cs
@@ -1,13 +1,21 @@
-﻿#nullable disable
+#nullable disable
 using System.Collections.Generic;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
+using CommandLineArgsGenerator.Styles;
 
 namespace CommandLineArgsGenerator
 {
     public class RootCommand : CommandInfoBase
     {
-        public ClassDeclarationSyntax Class { get; set; }     
+        public ClassDeclarationSyntax Class { get; set; }
 		public List<CommandInfoBase> Children { get; set; }
         public CommandInfoBase Default { get; set; }
+        public NamingStyle ParamStyle { get; set; } = NamingStyle.AllVariants;
+        public NamingStyle EnumStyle { get; set; } = NamingStyle.AllVariants;
+        public SeparatorStyle ValueSeparator { get; set; } = SeparatorStyle.All;
+        public PrefixStyle ArgPrefix { get; set; } = PrefixStyle.All;
+        public MandatoryStyle MandatoryStyle { get; set; } = MandatoryStyle.Mixed;
+        public bool SkipCommandParsing { get; set; }
+        public string? HelpCommand { get; set; } = "help";
 	}
-} 
+}

--- a/src/StyleEnums.cs
+++ b/src/StyleEnums.cs
@@ -1,0 +1,40 @@
+using System;
+
+namespace CommandLineArgsGenerator.Styles
+{
+    [Flags]
+    public enum NamingStyle
+    {
+        KebabCase       = 1,
+        SnakeCase       = 2,
+        DotCase         = 4,
+        NoSeparator     = 8,
+        CaseInsensitive = 16,
+        AllVariants     = KebabCase | SnakeCase | DotCase | NoSeparator | CaseInsensitive
+    }
+
+    [Flags]
+    public enum SeparatorStyle
+    {
+        Whitespace = 1,
+        Colon      = 2,
+        Equals     = 4,
+        All        = Whitespace | Colon | Equals
+    }
+
+    [Flags]
+    public enum PrefixStyle
+    {
+        Slash        = 1,
+        Hyphen       = 2,
+        DoubleHyphen = 4,
+        All          = Slash | Hyphen | DoubleHyphen
+    }
+
+    public enum MandatoryStyle
+    {
+        Mixed      = 0,
+        Positional = 1,
+        Named      = 2,
+    }
+}

--- a/src/templates/AppAttribute.cs
+++ b/src/templates/AppAttribute.cs
@@ -1,9 +1,16 @@
 using System;
-namespace NAMESPACE 
+using CommandLineArgsGenerator.Styles;
+namespace NAMESPACE
 {
     [AttributeUsage(AttributeTargets.Class)]
-    public class AppAttribute : Attribute 
+    public class AppAttribute : Attribute
     {
-        
+        public NamingStyle ParamStyle { get; set; } = NamingStyle.AllVariants;
+        public NamingStyle EnumStyle { get; set; } = NamingStyle.AllVariants;
+        public SeparatorStyle ValueSeparator { get; set; } = SeparatorStyle.All;
+        public PrefixStyle ArgPrefix { get; set; } = PrefixStyle.All;
+        public MandatoryStyle MandatoryStyle { get; set; } = MandatoryStyle.Mixed;
+        public bool SkipCommandParsing { get; set; } = false;
+        public string HelpCommand { get; set; } = "help";
     }
 }

--- a/src/templates/Completion.template
+++ b/src/templates/Completion.template
@@ -1,26 +1,30 @@
 {{~func GenCases(cmd)~}}
-    {{ if cmd.Children }} 
-        case "{{cmd.Name}}":
+    {{ if cmd.Children }}
+        {{ for variant in cmd.NameVariants }}
+        case "{{variant}}":
+        {{ end }}
         {
             args = new ArraySegment<string>(args.Array, args.Offset + 1, args.Count - 1);
             if(args.Count == 0 && isPosOutOfBound)
-                Result("{{cmd.Children | array.map "Name" | Join "\\n"}}");
+                Result("{{cmd.Children | array.each @(do; ret $0.NameVariants[0]; end) | Join "\\n"}}");
 			else if(args.Count == 0)
 				Result("");
             switch(args[0])
             {
                 {{ for c in cmd.Children; GenCases(c); end }}
-                
-                {{ if array.size(cmd.Children) > 0 }} 
-                case string s: 
-                    Result((new string[] { {{cmd.Children | array.map "Name" | array.each @(do; ret ("\"" + $0 + "\""); end) | Join ", "}} }).Where(x => x.Contains(s)) );
+
+                {{ if array.size(cmd.Children) > 0 }}
+                case string s:
+                    Result((new string[] { {{cmd.Children | array.each @(do; ret ("\"" + $0.NameVariants[0] + "\""); end) | Join ", "}} }).Where(x => x.Contains(s)) );
                     break;
                 {{ end }}
             }
             break;
         }
     {{ else }}
-        case "{{cmd.Name}}":
+        {{ for variant in cmd.NameVariants }}
+        case "{{variant}}":
+        {{ end }}
         {
             args = new ArraySegment<string>(args.Array, args.Offset + 1, args.Count - 1);
             if(args.Count == 0)
@@ -28,12 +32,26 @@
             {{ if (cmd.Options | array.size) > 0 }}
             switch(args[args.Count - 1])
             {
+                {{ for param in (cmd.Parameters | array.filter @(do; ret $0.IsEnum; end)) }}
+
+                {{if param.Alias }}
+                case "-{{param.Alias}}":
+                {{end}}
+                case "--{{param.NameVariants[0]}}":
+                {
+                    if(!isPosOutOfBound)
+                        break;
+                    Result("{{param.Type | GetEnumMembers | Join "\\n"}}");
+                    break;
+                }
+                {{ end }}
+
                 {{ for opt in (cmd.Options | array.filter @(do; ret $0.IsEnum; end)) }}
-                
+
                 {{if opt.Alias }}
                 case "-{{opt.Alias}}":
                 {{end}}
-                case "--{{opt.Name}}":
+                case "--{{opt.NameVariants[0]}}":
                 {
                     if(!isPosOutOfBound)
                         break;
@@ -41,25 +59,25 @@
                     break;
                 }
                 {{ end }}
-                
-                {{ if array.size(cmd.Options) > 0 }} 
+
+                {{ if array.size(cmd.Options) > 0 }}
                 case string option when option.StartsWith("--"):
                 {
-                    Result(new string[] { {{ cmd.Options | array.map "Name" | array.each @(do; ret ("\"--" + $0 + "\""); end) | Join ", "}} }.Where(x => x.StartsWith(option)));
+                    Result(new string[] { {{ cmd.Options | array.each @(do; ret ("\"--" + $0.NameVariants[0] + "\""); end) | Join ", "}} }.Where(x => x.StartsWith(option)));
                     break;
                 }
                 case string aliasOpt when aliasOpt.StartsWith("-"):
                 {
-                    Result(new string[] { {{ cmd.Options | array.filter @(do; ret $0.Alias; end) | array.map "Alias" | array.each @(do; ret ("\"-" + $0 + "\""); end) | Join ", "}} }.Where(x => x.StartsWith(aliasOpt)));
+                    Result(new string[] { {{ cmd.Parameters | array.filter @(do; ret $0.Alias; end) | array.map "Alias" | array.each @(do; ret ("\"-" + $0 + "\""); end) | Join ", "}}{{ if (cmd.Parameters | array.filter @(do; ret $0.Alias; end) | array.size) > 0 && (cmd.Options | array.filter @(do; ret $0.Alias; end) | array.size) > 0 }}, {{ end }}{{ cmd.Options | array.filter @(do; ret $0.Alias; end) | array.map "Alias" | array.each @(do; ret ("\"-" + $0 + "\""); end) | Join ", "}} }.Where(x => x.StartsWith(aliasOpt)));
                     break;
-                } 
+                }
                 {{ end }}
             }
             {{ end }}
             break;
         }
     {{ end }}
-    
+
 {{~ end ~}}
 using System;
 using System.Collections.Generic;
@@ -67,11 +85,11 @@ using System.Linq;
 using System.IO;
 namespace {{ Namespace }}
 {
-    public class Completer 
+    public class Completer
     {
         private static void Result(IEnumerable<string> res)
         {
-            Console.WriteLine(string.Join("\n", res)); 
+            Console.WriteLine(string.Join("\n", res));
 			Environment.Exit(0);
         }
         private static void Result(string res)
@@ -92,16 +110,16 @@ namespace {{ Namespace }}
             return true;
         }
         public static void Complete(ArraySegment<string> args, int position)
-        { 
+        {
             bool isPosOutOfBound = IsPositionOutOfBounds(args, position);
             if(args.Count == 0)
-                Result("{{Join(Root.Children | array.map "Name", "\\n")}}");
+                Result("{{Join(Root.Children | array.each @(do; ret $0.NameVariants[0]; end), "\\n")}}");
             switch(args[0])
             {
                 {{for c in Root.Children; GenCases c; end}}
-                {{ if array.size(Root.Children) > 0 }} 
-                case string s: 
-                    Result((new string[] { {{Root.Children | array.map "Name" | array.each @(do; ret ("\"" + $0 + "\""); end) | Join ", "}} }).Where(x => x.Contains(s)) );
+                {{ if array.size(Root.Children) > 0 }}
+                case string s:
+                    Result((new string[] { {{Root.Children | array.each @(do; ret ("\"" + $0.NameVariants[0] + "\""); end) | Join ", "}} }).Where(x => x.Contains(s)) );
                     break;
                 {{ end }}
             }

--- a/src/templates/DefaultCommandAttribute.cs
+++ b/src/templates/DefaultCommandAttribute.cs
@@ -1,0 +1,8 @@
+using System;
+namespace NAMESPACE
+{
+    [AttributeUsage(AttributeTargets.Class | AttributeTargets.Method)]
+    public class DefaultCommandAttribute : Attribute
+    {
+    }
+}

--- a/src/templates/EnumParser.template
+++ b/src/templates/EnumParser.template
@@ -1,20 +1,22 @@
 namespace {{ Namespace }}
 {
-    public static class EnumParser 
-    {  
+    public static class EnumParser
+    {
         {{ for i in EnumsInfo }}
         public static {{ i.Item3 }} Parse_{{ i.Item2 }}(string value)
         {
-            switch(value.ToLower())
+            switch(value{{ if EnumCaseInsensitive }}.ToLower(){{ end }})
             {
                 {{ for val in i.Item1 }}
                 {{ if val != ".ctor" }}
-                case "{{ val | TransformName }}":
+                {{ for variant in (val | GetNameVariants) }}
+                case "{{ variant }}":
+                {{ end }}
                     return {{ i.Item3 }}.{{ val }};
                 {{ end }}
                 {{ end }}
             }
-            throw new System.Exception("Cannot parse enum");
+            throw new System.Exception($"Cannot parse enum value '{value}' for type '{{ i.Item3 }}'");
         }
         {{ end }}
     }

--- a/src/templates/HelpTexts.template
+++ b/src/templates/HelpTexts.template
@@ -67,7 +67,7 @@
                     sb.AppendLine({{cmd.UnderscoredName}});
 				sb.AppendLine("subcommands:");
 				{{ if cmd.Default }}
-				sb.Append("\t(default)").Append("{{cmd.Default.Name}}");
+				sb.Append("\t(default)").Append("{{cmd.Default.NameVariants[0]}}");
 				if(!string.IsNullOrEmpty({{cmd.Default.UnderscoredName}}))
 				{
 					sb.Append(" - ").Append({{cmd.Default.UnderscoredName}});
@@ -75,7 +75,7 @@
 				sb.Append('\n');
 				{{ end }}
 				{{ for c in cmd.Children }}
-				sb.Append('\t').Append("{{c.Name}}");
+				sb.Append('\t').Append("{{c.NameVariants[0]}}");
 				if(!string.IsNullOrEmpty({{c.UnderscoredName}}))
 				{
 					sb.Append(" - ").Append({{c.UnderscoredName}});
@@ -88,7 +88,11 @@
 					sb.AppendLine("parameters:");
 					{{ for param in cmd.Parameters }}
 						{{ name = cmd.UnderscoredName + "_" + param.RawName }}
-						sb.Append('\t').Append("{{ param.Name }}");
+						{{ if MandatoryNamed }}
+						sb.Append('\t'){{ if param.Alias; ".Append(\"" + AliasPrefixes[0] + param.Alias + "|\")"; end}}.Append("{{ OptionPrefixes[0] }}{{ param.NameVariants[0] }}");
+						{{ else }}
+						sb.Append('\t').Append("<{{ param.NameVariants[0] }}>");
+						{{ end }}
 						if(!string.IsNullOrEmpty({{name}}))
 						{
 							sb.Append(" - ").Append({{name}});
@@ -99,14 +103,16 @@
 				sb.AppendLine("options:");
 				{{ for option in cmd.Options}}
 					{{ name = cmd.UnderscoredName + "_" + option.RawName }}
-					sb.Append('\t'){{ if option.Alias; ".Append(\"-" + option.Alias + "|\")"; end}}.Append("--{{ option.Name }}");
+					sb.Append('\t'){{ if option.Alias; ".Append(\"" + AliasPrefixes[0] + option.Alias + "|\")"; end}}.Append("{{ OptionPrefixes[0] }}{{ option.NameVariants[0] }}");
 					if(!string.IsNullOrEmpty({{name}}))
 					{
 						sb.Append(" - ").Append({{name}});
 					}
 					sb.Append('\n');
                 {{ end }} 
-                sb.Append("\t--help - shows this message\n");
+                {{ if HelpCommand }}
+                sb.Append("\t{{ HelpCommand }} - shows this message\n");
+                {{ end }}
 			{{ end }}	
 			return sb.ToString();
         }

--- a/src/templates/Parser.template
+++ b/src/templates/Parser.template
@@ -1,5 +1,5 @@
 {{ convs = {} }}
-{{~ func ShortHelp(cmd) ~}}{{ cmd.Name }}{{ if cmd && cmd.HelpText && !cmd.HelpText.IsEmpty }} - { HelpTexts.{{ cmd.UnderscoredName }} }{{~ end ~}}{{~ end~}}
+{{~ func ShortHelp(cmd) ~}}{{ cmd.NameVariants[0] }}{{ if cmd && cmd.HelpText && !cmd.HelpText.IsEmpty }} - { HelpTexts.{{ cmd.UnderscoredName }} }{{~ end ~}}{{~ end~}}
 {{~
     func GetCmdHelp(command)
 ~}}
@@ -16,15 +16,20 @@
 		end
 	end
 ~}}
+{{~ func HelpCaseLabels(variants) ~}}
+{{~ for variant in variants ~}}
+            case "{{ variant }}":
+{{~ end ~}}
+{{~ end ~}}
 {{~ func Help(command)
         if command.Children
 ~}}
-            case "{{ command.FullName }}": 
+            {{~ HelpCaseLabels(command.FullNameVariants) ~}}
                 return HelpTexts.Full_{{command.UnderscoredName}};
             {{ for cmd in command.Children; Help(cmd); end }}
         {{ if command.Default; Help(command.Default); end }}
         {{~ else ~}}
-            case "{{ command.FullName }}":
+            {{~ HelpCaseLabels(command.FullNameVariants) ~}}
                 return HelpTexts.Full_{{command.UnderscoredName}};
         {{~ end ~}}
 
@@ -35,7 +40,7 @@
     end
  ~}}
 
-{{~ func GenerateConverter(param, valueToParse) ~}} 
+{{~ func ParamConverter(param, valueToParse) ~}}
     {{ if convs | object.has_key param.DisplayTypeName }}
         {{ param.RawName }} = {{ convs[param.DisplayTypeName]}}.Convert({{ valueToParse }});
     {{ else if param.IsString }}
@@ -52,135 +57,264 @@
     {{ else; Error("Cannot create convertor for "+ param.DisplayTypeName) }}
     {{ end }}
 {{~ end ~}}
-{{~ func GenerateOptionConverter(option) ~}}
-    {{ valueToParse = option.RawName + "Raw" }}
-    {{ if option.IsArray }}
-        {{ if convs | object.has_key option.DisplayTypeName }}
-            {{ option.RawName }} = {{ valueToParse }}.Select(o => {{ convs[option.DisplayTypeName]}}.Convert(o)).ToArray();
-        {{ else if option.IsString }}
-            {{ option.RawName }} = {{ valueToParse }}.ToArray();
-        {{ else if option.IsEnum }}
-            {{ option.RawName }} = {{ valueToParse }}.Select(o => EnumParser.Parse_{{option.UnderscoredTypeName}}(o)).ToArray();
-        {{ else if HasMethod(option, "Parse", 1)}}
-            {{ option.RawName }} = {{ valueToParse }}.Select(o => {{ option.DisplayTypeName}}.Parse(o)).ToArray();
-        {{ else if HasMethod(option, "TryParse", 2)}}
-            {{option.RawName}} = {{ valueToParse }}.Select(o => {
-                if(!{{ option.DisplayTypeName }}.TryParse(o, out var val))
-                    throw new Exception();
-                return val;
-            }).ToArray();
-        {{ else if HasCtor(option, ["string"])}}
-            {{ option.RawName }} = {{ valueToParse }}.Select(o => new {{ option.DisplayTypeName}}(o)).ToArray();
-        {{ else; Error("Cannot create convertor for "+ option.DisplayTypeName) }}
-        {{ end }}
-    {{ else }}
-        {{ GenerateConverter(option, option.RawName + "Raw") }}
+{{~ func ArrayConverter(item, valueToParse) ~}}
+    {{ if convs | object.has_key item.DisplayTypeName }}
+        {{ item.RawName }} = {{ valueToParse }}.Select(o => {{ convs[item.DisplayTypeName]}}.Convert(o)).ToArray();
+    {{ else if item.IsString }}
+        {{ item.RawName }} = {{ valueToParse }}.ToArray();
+    {{ else if item.IsEnum }}
+        {{ item.RawName }} = {{ valueToParse }}.Select(o => EnumParser.Parse_{{item.UnderscoredTypeName}}(o)).ToArray();
+    {{ else if HasMethod(item, "Parse", 1)}}
+        {{ item.RawName }} = {{ valueToParse }}.Select(o => {{ item.DisplayTypeName}}.Parse(o)).ToArray();
+    {{ else if HasMethod(item, "TryParse", 2)}}
+        {{item.RawName}} = {{ valueToParse }}.Select(o => {
+            if(!{{ item.DisplayTypeName }}.TryParse(o, out var val))
+                throw new Exception();
+            return val;
+        }).ToArray();
+    {{ else if HasCtor(item, ["string"])}}
+        {{ item.RawName }} = {{ valueToParse }}.Select(o => new {{ item.DisplayTypeName}}(o)).ToArray();
+    {{ else; Error("Cannot create convertor for "+ item.DisplayTypeName) }}
     {{ end }}
 {{~ end ~}}
+{{~ func GenerateConverter(item, valueToParse) ~}}
+    {{ if item.IsArray }}
+        {{ ArrayConverter(item, valueToParse) }}
+    {{ else }}
+        {{ ParamConverter(item, valueToParse) }}
+    {{ end }}
+{{~ end ~}}
+{{~ func ConvertWithErrorHandling(item, valueToParse, itemKind) ~}}
+    try
+    {
+        {{ GenerateConverter(item, valueToParse) }}
+    }
+    catch(ArgumentParsingException exception)
+    {
+        Error($"Cannot parse {{ itemKind }} {{item.NameVariants[0]}}\n{exception.Message}");
+    }
+    catch
+    {
+        Error($"Cannot parse {{ itemKind }} '{{item.NameVariants[0]}}', value '{ {{~ valueToParse ~}} }' is not convertible to {{item.DisplayTypeName}}");
+    }
+{{~ end ~}}
 
-{{~ func GenerateCase(command, isDefault = false) ~}}
+{{~ func GenerateCase(command, isDefault = false, siblings = null, parentHelpKey = null) ~}}
 
 {{~ if isDefault ~}}
 case string _{{ command.RawName }}:
 {{~ else ~}}
-case "{{ command.Name }}":
+{{ for variant in command.NameVariants }}
+case "{{ variant }}":
+{{ end }}
 {{~ end ~}}
 {
     {{ if isDefault }}
-    if(_{{ command.RawName }} == "{{ command.Name }}")
+    {{ if !SkipCommandParsing }}
+    if({{ for variant in command.NameVariants }}{{ if !for.first }} || {{ end }}_{{ command.RawName }} == "{{ variant }}"{{ end }})
     {
         segment = new ArraySegment<string>(args, segment.Offset+1, segment.Count - 1);
     }
+    {{ if GenerateSuggestions && siblings }}
+    else
+    {
+        var _possibleCmd_{{ command.RawName }} = FindClosest(_{{ command.RawName }},
+            new[] { {{ if HelpCommand }}"{{ HelpCommand }}", {{ end }}{{ for cmd in siblings; "\"" + cmd.NameVariants[0] + "\", "; end }} });
+        if (_possibleCmd_{{ command.RawName }} is not null)
+        {
+            Console.WriteLine(GetHelp({{ if parentHelpKey }}"{{ parentHelpKey }}"{{ end }}));
+            Console.WriteLine($"Did you mean '{_possibleCmd_{{ command.RawName }}}'?");
+            return;
+        }
+    }
+    {{ end }}
+    {{ end }}
     {{ else }}
     segment = new ArraySegment<string>(args, segment.Offset+1, segment.Count - 1);
     {{ end }}
-    if(segment.FirstOrDefault() == "--help")
+    {{ if HelpCommand }}
+    if({{ for prefix in OptionPrefixes }}{{ if !for.first }} || {{ end }}segment.FirstOrDefault() == "{{ prefix }}{{ HelpCommand }}"{{ end }})
     {
-        Console.WriteLine(GetHelp("{{ command.FullName }}"));
+        Console.WriteLine(GetHelp("{{ command.FullNameVariants[0] }}"));
         return;
     }
+    {{ end }}
     {{ if command.Children }}
+    {{~ GenerateSubcommandSwitch(command) ~}}
+    {{ else }}
+    {{~ GenerateLeafParsing(command, isDefault) ~}}
+    {{ end }}
+    break;
+}
+{{~ end ~}}
+{{~ func GenerateCaseLabels(item) ~}}
+    {{ if item.Alias }}
+    {{ for prefix in AliasPrefixes }}
+    case "{{ prefix }}{{ item.Alias }}":
+    {{ end }}
+    {{ end }}
+    {{ for variant in item.NameVariants }}
+    {{ for prefix in OptionPrefixes }}
+    case "{{ prefix }}{{ variant }}":
+    {{ end }}
+    {{ end }}
+{{~ end ~}}
+{{~ func HandleUnknown(errorKind, command, includeParamSuggestions) ~}}
+                    {{ if GenerateSuggestions }}
+                    {
+                        var posible_{{command.RawName}} = FindClosest(optName,
+                            new string[]{ {{ if includeParamSuggestions }}{{ for param in command.Parameters; for pfx in OptionPrefixes; "\"" + pfx + param.NameVariants[0] + "\", "; end; if param.Alias; for pfx in AliasPrefixes; "\"" + pfx + param.Alias + "\", "; end; end; end }}{{ end }}{{ for opt in command.Options; for pfx in OptionPrefixes; "\"" + pfx + opt.NameVariants[0] + "\", "; end; if opt.Alias; for pfx in AliasPrefixes; "\"" + pfx + opt.Alias + "\", "; end; end; end }} });
+
+                        if(posible_{{command.RawName}} is not null)
+                        {
+                            Console.WriteLine(GetHelp("{{command.FullNameVariants[0]}}"));
+                            Console.WriteLine($"Did you mean '{posible_{{command.RawName}}}'?");
+                            Environment.Exit(0);
+                        }
+                        else
+                        {
+                            Error($"{{ errorKind }} {optPart}");
+                        }
+                    }
+                    {{ else }}
+                    Error($"{{ errorKind }} {optPart}");
+                    {{ end }}
+{{~ end ~}}
+{{~ func GenerateSubcommandSwitch(command) ~}}
     if(segment.Count < 1)
     {
-        Console.WriteLine(GetHelp("{{ command.FullName }}"));
+        Console.WriteLine(GetHelp("{{ command.FullNameVariants[0] }}"));
         return;
     }
-    switch(segment[0])
+    switch(segment[0]{{ if ParamCaseInsensitive }}.ToLower(){{ end }})
     {
         {{ for cmd in command.Children; GenerateCase(cmd); end }}
         {{~
         if command.Default
-            GenerateCase(command.Default, true)
+            GenerateCase(command.Default, true, command.Children, command.FullNameVariants[0])
         else
         ~}}
         case string {{ command.RawName}}_unknown:
             {{ if GenerateSuggestions }}
-            var posible_{{command.RawName}} = 
-                new[] { {{ for cmd in command.Children; "\"" + cmd.Name + "\", "; end }} }
-                .Select(cmd => (cmd, LevenshteinDistance.Calculate(cmd, {{ command.RawName }}_unknown )))
-                .OrderBy(x => x.Item2)
-                .ThenBy(x => x.Item1)
-                .FirstOrDefault(x => x.Item2 <= 2);
-            if(posible_{{command.RawName}}.Item1 is not null) 
+            var posible_{{command.RawName}} = FindClosest({{ command.RawName }}_unknown,
+                new[] { {{ for cmd in command.Children; "\"" + cmd.NameVariants[0] + "\", "; end }} });
+            if(posible_{{command.RawName}} is not null)
             {
-                Console.WriteLine(GetHelp("{{ command.FullName }}"));
-                Console.WriteLine($"Did you mean '{posible_{{command.RawName}}.Item1}'?");
+                Console.WriteLine(GetHelp("{{ command.FullNameVariants[0] }}"));
+                Console.WriteLine($"Did you mean '{posible_{{command.RawName}}}'?");
             }
             {{ else }}
-            Console.WriteLine(GetHelp("{{ command.FullName }}"));
-            Error("Unknown command");
+            Console.WriteLine(GetHelp("{{ command.FullNameVariants[0] }}"));
+            Error($"Unknown command '{ {{~ command.RawName ~}}_unknown}'");
             {{ end }}
             break;
         {{~ end ~}}
     }
-    {{ else }}
-    if(segment.Count < {{ command.Parameters | array.size }})
-    {
-       Error("Not all parameters are specified");
-    }
-    {{ if (command.Parameters | array.size) > 0 }}
+{{~ end ~}}
+{{~ func GenerateLeafParsing(command, isDefault) ~}}
+    {{~ paramCount = command.Parameters | array.size ~}}
+    {{~ optionCount = command.Options | array.size ~}}
+    {{ if paramCount > 0 }}
         {{ for parameter in command.Parameters }}
             {{ parameter.DisplayTypeName }}{{ parameter.IsNullable ? "?" : ""}} {{ parameter.RawName }} = default;
-            try
-            {
-                {{GenerateConverter(parameter, "segment[" + (for.index) + "]") }}
-            }
-            catch(ArgumentParsingException exception)
-            {
-                Error($"Cannot parse parameter {{parameter.Name}}\n{exception.Message}");
-            }
-            catch
-            {
-                Error("Cannot parse parameter {{parameter.Name}}");
-            }
+            bool {{ parameter.RawName }}_set = false;
         {{ end }}
     {{ end }}
-    {{ if (command.Options | array.size) > 0 }}
+    {{ if optionCount > 0 }}
         {{ for option in command.Options }}
             {{ option.IsArray ? "Queue<string>" : "string" }} {{ option.RawName }}Raw = null;
         {{ end }}
-        for(int i = {{ command.Parameters | array.size }}; i < segment.Count;)
+    {{ end }}
+    {{ if isDefault && paramCount == 0 && optionCount == 0 }}
+    if(segment.Count > 0)
+    {
+        Error($"Unexpected argument '{segment[0]}'");
+    }
+    {{ end }}
+    {{ if paramCount > 0 || optionCount > 0 }}
+    {
+        {{ if MandatoryPositional && paramCount > 0 }}
+        int _positionalIndex = 0;
+        {{ end }}
+        for(int i = 0; i < segment.Count;)
         {
-            switch(segment[i++])
+            var optPart = segment[i];
+            {{ if SeparatorColon || SeparatorEquals }}
+            string optName, optInlineValue = null;
+            var sepIdx = optPart.IndexOfAny(new[] { {{ if SeparatorColon }}':', {{ end }}{{ if SeparatorEquals }}'=' {{ end }} });
+            if(sepIdx >= 0) { optName = optPart.Substring(0, sepIdx); optInlineValue = optPart.Substring(sepIdx + 1); }
+            else { optName = optPart; }
+            i++;
+            {{ else }}
+            var optName = optPart;
+            i++;
+            {{ end }}
+            switch(optName{{ if ParamCaseInsensitive }}.ToLower(){{ end }})
             {
-                {{ for option in command.Options }}
-                {{ if option.Alias }}
-                case "-{{ option.Alias }}":
+                {{ if MandatoryNamed }}
+                {{ for parameter in command.Parameters }}
+                {{~ GenerateCaseLabels(parameter) ~}}
+                {
+                    string _val;
+                    {{ if SeparatorColon || SeparatorEquals }}
+                    if(optInlineValue != null) { _val = optInlineValue; }
+                    else
+                    {
+                    {{ end }}
+                        if(i >= segment.Count) { Error("Missing value for parameter '{{ parameter.NameVariants[0] }}'"); _val = null; }
+                        else { _val = segment[i++]; }
+                    {{ if SeparatorColon || SeparatorEquals }}
+                    }
+                    {{ end }}
+                    {{ ConvertWithErrorHandling(parameter, "_val", "parameter") }}
+                    {{ parameter.RawName }}_set = true;
+                }
+                break;
                 {{ end }}
-                case "--{{option.Name}}":
+                {{ end }}
+                {{ for option in command.Options }}
+                {{~ GenerateCaseLabels(option) ~}}
                     {{ if !option.IsBool }}
+                    {{ if SeparatorColon || SeparatorEquals }}
+                    if(optInlineValue != null)
+                    {
+                        {{ if option.IsArray }}
+                        {{ option.RawName}}Raw = new Queue<string>();
+                        {{ option.RawName}}Raw.Enqueue(optInlineValue);
+                        {{ else }}
+                        {{ option.RawName }}Raw = optInlineValue;
+                        {{ end }}
+                    }
+                    else
+                    {
+                    {{ end }}
                     if(i >= segment.Count)
                     {
-                        Error("Specify option value!");
+                        Error($"Specify value for option '{optName}'");
                     }
                     {{ end }}
                     {{ if option.IsArray }}
+                    {{ if SeparatorColon || SeparatorEquals }}
+                    if(optInlineValue == null)
+                    {
+                    {{ end }}
                     {{ option.RawName}}Raw = new Queue<string>();
                     while(i < segment.Count && !segment[i].StartsWith('-'))
                     {
                         {{ option.RawName}}Raw.Enqueue(segment[i++]);
                     }
+                    {{ if SeparatorColon || SeparatorEquals }}
+                    }
+                    {{ end }}
                     {{ else if option.IsBool }}
+                    {{ if SeparatorColon || SeparatorEquals }}
+                    if(optInlineValue != null)
+                    {
+                        {{ option.RawName }}Raw = optInlineValue;
+                    }
+                    else
+                    {
+                    {{ end }}
                     if(i < segment.Count && (segment[i].ToLower() == "true" || segment[i].ToLower() == "false"))
                     {
                         {{ option.RawName }}Raw = segment[i++];
@@ -193,61 +327,70 @@ case "{{ command.Name }}":
                         {{ option.RawName }}Raw = "true";
                         {{ end }}
                     }
+                    {{ if SeparatorColon || SeparatorEquals }}
+                    }
+                    {{ end }}
                     {{ else }}
+                        {{ if SeparatorColon || SeparatorEquals }}
+                        if(optInlineValue == null)
+                        {
+                        {{ end }}
                         {{ option.RawName }}Raw = segment[i++];
+                        {{ if SeparatorColon || SeparatorEquals }}
+                        }
+                        {{ end }}
+                    {{ end }}
+                    {{ if SeparatorColon || SeparatorEquals }}
+                    {{ if !option.IsBool }}
+                    }
+                    {{ end }}
                     {{ end }}
                 break;
                 {{ end }}
-                case string opt:
-                    {{ if GenerateSuggestions }}
+                default:
+                {{ if MandatoryPositional && paramCount > 0 }}
+                {
+                    switch(_positionalIndex++)
                     {
-                        var posible_{{command.RawName}} = 
-                            new string[]{ {{ for opt in command.Options; "\"--" + opt.Name + "\", "; if opt.Alias; "\"-" + opt.Alias + "\", "; end; end }} }
-                            .Select(cmd => (cmd, LevenshteinDistance.Calculate(cmd, opt)))
-                            .OrderBy(x => x.Item2)
-                            .ThenBy(x => x.Item1)
-                            .FirstOrDefault(x => x.Item2 <= 2);
-                            
-                        if(posible_{{command.RawName}}.Item1 is not null) 
-                        {
-                            Console.WriteLine(GetHelp("{{command.FullName}}"));
-                            Console.WriteLine($"Did you mean '{posible_{{command.RawName}}.Item1}'?");
-                            Environment.Exit(0);
-                        }
-                        else 
-                        {
-                            Error($"Unknown option {opt}");
-                        }
+                        {{ for parameter in command.Parameters }}
+                        case {{ for.index }}:
+                            {{ ConvertWithErrorHandling(parameter, "optPart", "parameter") }}
+                            {{ parameter.RawName }}_set = true;
+                            break;
+                        {{ end }}
+                        default:
+                            {{ HandleUnknown("Unexpected argument", command, true) }}
+                            break;
                     }
-                    {{ else }}
-                    Error($"Unknown option {opt}");
-                    {{ end }}
+                }
+                {{ else if paramCount > 0 }}
+                    {{ HandleUnknown("Unexpected argument", command, true) }}
+                {{ else }}
+                    {{ HandleUnknown("Unknown option", command, false) }}
+                {{ end }}
                     break;
             }
         }
+    }
+    {{ end }}
+    {{ if paramCount > 0 }}
+        {{ for parameter in command.Parameters }}
+        if(!{{ parameter.RawName }}_set)
+        {
+            Error("Missing required parameter '{{ parameter.NameVariants[0] }}'");
+        }
+        {{ end }}
+    {{ end }}
+    {{ if optionCount > 0 }}
         {{ for option in command.Options }}
             {{ option.DisplayTypeName }}{{option.IsArray ? "[]": ""}}{{option.IsNullable ? "?": ""}} {{ option.RawName}} = {{ option.Default ?? "default" }};
-            try
+            if({{option.RawName}}Raw != null)
             {
-                if({{option.RawName}}Raw != null)
-                {
-                    {{ GenerateOptionConverter(option) }}
-                }
-            }
-            catch(ArgumentParsingException exception)
-            {
-                Error($"Cannot parse option {{option.Name}}\n{exception.Message}");
-            }
-            catch
-            {
-                Error("Cannot parse option {{option.Name}}");
+                {{ ConvertWithErrorHandling(option, option.RawName + "Raw", "option") }}
             }
         {{ end }}
     {{ end }}
     {{ command.NameInSourceCode }}({{ JoinParamsAndOptions(command) }}){{~ if command.IsTask ~}}.GetAwaiter().GetResult(){{ end }};
-    {{ end }}
-    break;
-}
 {{~ end ~}}
 #nullable disable
 using System;
@@ -265,9 +408,19 @@ namespace {{ Namespace }}
                 {{ if Root.Default; Help(Root.Default); end }}
                 {{~ $cmdChars = (Root.Default != null) ? ['[', ']'] : [ '<', '>' ]~}}
                 default:
-                    return $"{{~ if Root.HelpText ~}}{ HelpTexts.Root }\n{{~ end ~}}Usage: {{$cmdChars[0]}}command{{$cmdChars[1]}} <parameters> [options]\ncommands:\n\thelp - shows help text of command\n{{~if Root.Default ~}}\t(default){{~ ShortHelp(Root.Default) ~}}\n{{~ end ~}}{{~for cmd in Root.Children~}}\t{{ShortHelp(cmd)}}\n{{~ end ~}}";
+                    return $"{{~ if Root.HelpText ~}}{ HelpTexts.Root }\n{{~ end ~}}Usage: {{$cmdChars[0]}}command{{$cmdChars[1]}} <parameters> [options]\ncommands:\n{{~ if HelpCommand ~}}\t{{ HelpCommand }} - shows help text of command\n{{~ end ~}}{{~if Root.Default ~}}\t(default){{~ ShortHelp(Root.Default) ~}}\n{{~ end ~}}{{~for cmd in Root.Children~}}\t{{ShortHelp(cmd)}}\n{{~ end ~}}";
             }
 		}
+		{{ if GenerateSuggestions }}
+		private static string FindClosest(string input, string[] candidates, int maxDistance = 2)
+		{
+			return candidates
+				.Select(c => (c, LevenshteinDistance.Calculate(c, input)))
+				.OrderBy(x => x.Item2)
+				.ThenBy(x => x.Item1)
+				.FirstOrDefault(x => x.Item2 <= maxDistance).Item1;
+		}
+		{{ end }}
 		private static void Error(string error)
 		{
 			Console.ForegroundColor = ConsoleColor.Red;
@@ -301,9 +454,13 @@ namespace {{ Namespace }}
                     {{ convs[targetType] = convName }}
                 {{ end }}
             {{ end }}
-            switch(segment[0])
+            switch(segment[0]{{ if ParamCaseInsensitive }}.ToLower(){{ end }})
             {
-                case "help":
+                {{ if HelpCommand }}
+                case "{{ HelpCommand }}":
+                {{ for prefix in OptionPrefixes }}
+                case "{{ prefix }}{{ HelpCommand }}":
+                {{ end }}
                     if(args.Length == 1)
                     {
                         Console.WriteLine(GetHelp());
@@ -313,6 +470,7 @@ namespace {{ Namespace }}
                         Console.WriteLine(GetHelp(string.Join(" ", args.Skip(1))));
                     }
                     break;
+                {{ end }}
                 {{~ if GenerateCompletion }}
                 case "complete":
                 {
@@ -337,7 +495,7 @@ namespace {{ Namespace }}
 						pos -= spl[0].Length + 1;
 						segment = new ArraySegment<string>(spl, 1, spl.Length - 1);
                     }
-					else 
+					else
 					{
 						segment = new ArraySegment<string>(segment.Array, segment.Offset + 3, segment.Count - 3);
 					}
@@ -346,31 +504,27 @@ namespace {{ Namespace }}
                 }
                 {{~ end ~}}
                 {{ for cmd in Root.Children; GenerateCase(cmd); end }}
-                {{ if Root.Default; GenerateCase(Root.Default, true); }}
+                {{ if Root.Default; GenerateCase(Root.Default, true, Root.Children, null); }}
                 {{else}}
-                case string unknowncmd: 
+                case string unknowncmd:
                 {{ if GenerateSuggestions }}
                 {
-                    var posible = 
-                        new[] { "help", {{ for cmd in Root.Children; "\"" + cmd.Name + "\", "; end }} }
-                        .Select(cmd => (cmd, LevenshteinDistance.Calculate(cmd, unknowncmd)))
-                        .OrderBy(x => x.Item2)
-                        .ThenBy(x => x.Item1)
-                        .FirstOrDefault(x => x.Item2 <= 2);
-                    if(posible.Item1 is not null) 
+                    var posible = FindClosest(unknowncmd,
+                        new[] { {{ if HelpCommand }}"{{ HelpCommand }}", {{ end }}{{ for cmd in Root.Children; "\"" + cmd.NameVariants[0] + "\", "; end }} });
+                    if(posible is not null)
                     {
                         Console.WriteLine(GetHelp());
-                        Console.WriteLine($"Did you mean '{posible.Item1}'?");
-                    } 
-                    else 
-                    {                                
+                        Console.WriteLine($"Did you mean '{posible}'?");
+                    }
+                    else
+                    {
                         Console.WriteLine(GetHelp());
-                        Error("Unknown command");
+                        Error($"Unknown command '{unknowncmd}'");
                     }
                 }
                 {{ else }}
                 Console.WriteLine(GetHelp());
-                Error("Unknown command");
+                Error($"Unknown command '{unknowncmd}'");
                 {{ end }}
                 break;
                 {{ end }}


### PR DESCRIPTION
List of changes:
* more detailed error texts (eg. `Bad 'my-param', value 'abc' not convertible to int`)
* configurable "help" command.
* support for any case for commands and enums (`kebab-case`, `snake_case`, `dot.case`, `camelCase`), configurable.
* support more parameters/options prefixes (`--`,`/`,`-`), configurable
* support more separators for `paramName=paramValue` pairs (` `, `=`, `:`), configurable.
* support named mandatory parameters, configurable.
* help texts reflect configured prefixes.
* Automatic Default command if it is only one command.
* Default command setting via attribute (some IDEs viewer generators ignore xmldocs)
* Changes reflected in help text.